### PR TITLE
Add returnCompleteBalances

### DIFF
--- a/poloniex_test.go
+++ b/poloniex_test.go
@@ -23,3 +23,41 @@ func TestClient_GetCurrencies(t *testing.T) {
 		t.Fatal("ret should be non nil")
 	}
 }
+
+func TestClient_GetBalances(t *testing.T) {
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	client, err := NewPrivateClient(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ret, err := client.GetBalances(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret == nil {
+		t.Fatal("ret should be non nil")
+	}
+}
+
+func TestClient_GetCompleteBalances(t *testing.T) {
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	client, err := NewPrivateClient(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ret, err := client.GetCompleteBalances(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret == nil {
+		t.Fatal("ret should be non nil")
+	}
+}
+
+func NewPrivateClient(logger *log.Logger) (*Client, error) {
+	return New("POLONIEX_KEY", "POLONIEX_SECRET", "", logger)
+}

--- a/private-api.go
+++ b/private-api.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 )
 
+// GetBalances returns all of available balances.
 func (c *Client) GetBalances(ctx context.Context) (*Balances, error) {
 	resp, err := c.doPrivateAPIRequest(ctx, "returnBalances", nil)
 	if err != nil {
@@ -35,10 +36,13 @@ func (c *Client) GetBalances(ctx context.Context) (*Balances, error) {
 	return &balance, nil
 }
 
+// Balances is a pair of symbol with ammount.
 type Balances struct {
 	Pair map[string]float64
 }
 
+// GetCompleteBalances returns all of balances, including available balance,
+// balance on orders, and the estimated BTC value of balance.
 func (c *Client) GetCompleteBalances(ctx context.Context) (CompleteBalances, error) {
 	resp, err := c.doPrivateAPIRequest(ctx, "returnCompleteBalances", nil)
 	if err != nil {
@@ -56,8 +60,11 @@ func (c *Client) GetCompleteBalances(ctx context.Context) (CompleteBalances, err
 	return ret, nil
 }
 
+// CompleteBalances is a pair of symbol with Balance.
 type CompleteBalances map[string]Balance
 
+// A Balance is including available balance, balance on order, and the
+// estimated BTC value of balance.
 type Balance struct {
 	Available string
 	OnOrders  string

--- a/private-api.go
+++ b/private-api.go
@@ -57,28 +57,26 @@ func (c *Client) GetCompleteBalances(ctx context.Context) (CompleteBalances, err
 		return nil, errors.New(msg.(string))
 	}
 
-	balances := []Balance{}
+	balances := make(CompleteBalances)
 	for k, v := range ret {
 		balance := v.(map[string]interface{})
 		i, err := strconv.ParseFloat(balance["btcValue"].(string), 64)
 		if i == 0 || err != nil {
 			continue
 		}
-		balances = append(balances, Balance{
-			Symbol:    k,
+		balances[k] = Balance{
 			Available: balance["available"].(string),
 			OnOrders:  balance["onOrders"].(string),
 			BtcValue:  balance["btcValue"].(string),
-		})
+		}
 	}
 
 	return balances, nil
 }
 
-type CompleteBalances []Balance
+type CompleteBalances map[string]Balance
 
 type Balance struct {
-	Symbol    string
 	Available string
 	OnOrders  string
 	BtcValue  string

--- a/private-api.go
+++ b/private-api.go
@@ -49,29 +49,11 @@ func (c *Client) GetCompleteBalances(ctx context.Context) (CompleteBalances, err
 		return nil, errors.New(resp.Status)
 	}
 
-	var ret map[string]interface{}
+	var ret CompleteBalances
 	if err := c.decodeResponse(resp, &ret, nil); err != nil {
 		return nil, err
 	}
-	if msg, got := ret["error"]; got {
-		return nil, errors.New(msg.(string))
-	}
-
-	balances := make(CompleteBalances)
-	for k, v := range ret {
-		balance := v.(map[string]interface{})
-		i, err := strconv.ParseFloat(balance["btcValue"].(string), 64)
-		if i == 0 || err != nil {
-			continue
-		}
-		balances[k] = Balance{
-			Available: balance["available"].(string),
-			OnOrders:  balance["onOrders"].(string),
-			BtcValue:  balance["btcValue"].(string),
-		}
-	}
-
-	return balances, nil
+	return ret, nil
 }
 
 type CompleteBalances map[string]Balance


### PR DESCRIPTION
Poloniex Trading API `returnCompleteBalances` returns

```json
{"LTC":{"available":"5.015","onOrders":"1.0025","btcValue":"0.078"},"NXT:{...} ... }
```

but `GetCompleteBalances` method returns below structs.

```go
type CompleteBalances []Balance

type Balance struct {
	Symbol    string
	Available string
	OnOrders  string
	BtcValue  string
}
```

How is this?
